### PR TITLE
Organize scripts and initialize runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore runtime output directories
+system/*
+!system/README.md
+Downloads/
+build/
+__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
 # Script-YTD
 
 This repository contains a helper script for downloading media from the
-clipboard on Windows. The `main_windows_strict.py` script places an icon in the
-system tray and reacts to global hotkeys.
+clipboard on Windows. The `scripts/main_windows_strict.py` script places an
+icon in the system tray and reacts to global hotkeys.
 
 ## Repository layout
 
-- `main_windows_strict.py` – main application script
+- `scripts/main_windows_strict.py` – main application script
+- `scripts/build.py` – installs missing packages and builds an executable
 - `requirements.txt` – list of required Python packages such as
   `yt-dlp`, `requests`, `beautifulsoup4`, `keyboard`, `pystray`,
   `pyperclip`, `pillow`, `pyinstaller`, and `pywin32`
-- `build.py` – installs missing packages and builds an executable
 - `icons/` – tray icons used by the application
 - `system/` – configuration, logs and build output
 
 ## Quick start
 
 1. Install Python 3.10 or newer.
-2. Run `python build.py`.
+2. Run `python scripts/build.py`.
    The script installs required packages and builds an executable in `system/`.
 3. Launch the generated `.exe` from the `system` directory.
+
+## Usage
+
+Select a link in your browser and press `Ctrl+Space`. The script copies the
+selection to the clipboard and appends the URL to `system/download-list.txt`.
 
 ## Manual commands
 
@@ -34,7 +39,7 @@ Build the executable manually with PyInstaller:
 ```bash
 pyinstaller --noconsole --onefile --icon icons/ico.ico \
   --add-data "icons;icons" --add-data "system;system" \
-  --distpath system main_windows_strict.py
+  --distpath system scripts/main_windows_strict.py
 ```
 
 The icons folder contains three images used in the tray:
@@ -50,3 +55,5 @@ The first launch creates a `Downloads/` directory with these subfolders:
 - `Pictures/Wildberries/` – Wildberries product images
 
 All runtime files (config, logs and download list) are stored in the `system/` folder.
+The repository includes an empty `system/` directory; required files will be
+created automatically on first launch.

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -47,6 +47,7 @@ def create_runtime_dirs() -> None:
 def build_exe() -> None:
     """Build executable using PyInstaller."""
     sep = ';' if sys.platform == 'win32' else ':'
+    script = os.path.join(os.path.dirname(__file__), 'main_windows_strict.py')
     cmd = [
         sys.executable, '-m', 'PyInstaller',
         '--noconsole',
@@ -55,7 +56,7 @@ def build_exe() -> None:
         '--add-data', f'icons{sep}icons',
         '--workpath', 'build',
         '--distpath', 'system',
-        'main_windows_strict.py',
+        script,
     ]
     subprocess.check_call(cmd)
 

--- a/scripts/main_windows_strict.py
+++ b/scripts/main_windows_strict.py
@@ -127,6 +127,15 @@ INFO_FILE = os.path.join(SYSTEM_DIR, 'info.txt')
 os.makedirs(SYSTEM_DIR, exist_ok=True)
 
 
+def ensure_system_files() -> None:
+    """Create default files in the ``system`` directory if missing."""
+    if not os.path.exists(CONFIG_FILE):
+        save_config(DEFAULT_CONFIG)
+    for path in (DOWNLOAD_LIST, LOG_FILE, INFO_FILE):
+        if not os.path.exists(path):
+            open(path, 'a', encoding='utf-8').close()
+
+
 # Эти переменные инициализируются после загрузки конфигурации
 DOWNLOADS_FOLDER = os.path.join(ROOT_DIR, 'Downloads')
 VIDEOS_FOLDER = os.path.join(DOWNLOADS_FOLDER, 'Videos')
@@ -511,10 +520,10 @@ def add_link_from_clipboard() -> None:
 def main() -> None:
     """Запускает горячие клавиши и значок в трее."""
     ensure_single_instance()
-    config = load_config()
     ensure_directories()
-    if not os.path.exists(DOWNLOAD_LIST):
-        open(DOWNLOAD_LIST, 'a', encoding='utf-8').close()
+    ensure_system_files()
+    config = load_config()
+    logging.info('Script started')
 
     add_hotkey = config.get('add_hotkey', DEFAULT_CONFIG['add_hotkey'])
     download_hotkey = config.get('download_hotkey', DEFAULT_CONFIG['download_hotkey'])
@@ -604,6 +613,7 @@ def main() -> None:
     print(f"Значок размещён в трее. Горячие клавиши {add_hotkey} и {download_hotkey} активны.")
     tray_icon.run()
     hotkey_manager.unregister_all()
+    logging.info('Script stopped')
     print('Скрипт завершён.')
 
 if __name__ == '__main__':

--- a/scripts/main_windows_strict.spec
+++ b/scripts/main_windows_strict.spec
@@ -2,7 +2,7 @@
 
 
 a = Analysis(
-    ['main_windows_strict.py'],
+    ['scripts/main_windows_strict.py'],
     pathex=[],
     binaries=[],
     datas=[('icons', 'icons')],

--- a/system/README.md
+++ b/system/README.md
@@ -1,0 +1,1 @@
+Runtime files are generated here on first launch.


### PR DESCRIPTION
## Summary
- move Python scripts to `scripts/`
- create placeholder `system/` directory
- add `.gitignore`
- document new structure and usage
- generate default runtime files on first run
- adjust build and spec files

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6883bb3c2bbc8333bd993ac8a226ae8f