### PR TITLE
Add clipboard_only option for clipboard reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ The first launch creates a `Downloads/` directory with these subfolders:
 All runtime files (config, logs and download list) are stored in the `system/` folder.
 The repository includes an empty `system/` directory; required files will be
 created automatically on first launch.
+
+## Configuration
+
+Runtime options are stored in `system/config.ini`.
+Set `clipboard_only = true` under the `[options]` section to use the current
+clipboard contents when adding a link instead of sending `Ctrl+C` to copy the
+selection. This is useful for browsers or programs that block automated copy
+commands.


### PR DESCRIPTION
## Summary
- support a new `clipboard_only` option in `config.ini`
- use `read_clipboard()` when the option is enabled
- document the new configuration flag

## Testing
- `python -m py_compile scripts/main_windows_strict.py`
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f7b595a88333ae43068f0a1ee214