### PR TITLE
Fix default behavior for adding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ icon in the system tray and reacts to global hotkeys.
 
 ## Usage
 
-Select a link in your browser and press `Ctrl+Space`. The script copies the
-selection to the clipboard and appends the URL to `system/download-list.txt`.
+Copy a link to your clipboard and press `Ctrl+Space`. The script takes the
+clipboard contents and appends the URL to `system/download-list.txt`.
 
 ## Changing hotkeys
 
 The script registers global shortcuts. By default `Ctrl+Space` adds the
-current selection to the list and `Ctrl+Shift+Space` starts downloading. You
+ contents of the clipboard to the list and `Ctrl+Shift+Space` starts downloading. You
 can redefine these keys at runtime: right-click the tray icon and choose
 **Горячие клавиши**, then press the new combination and hit Enter. The chosen
 values are stored in `system/config.ini` and loaded on the next launch.

--- a/scripts/main_windows_strict.py
+++ b/scripts/main_windows_strict.py
@@ -187,7 +187,10 @@ def flash_tray_icon(icon: pystray.Icon, image: Image.Image, duration: float = 0.
 DEFAULT_CONFIG = {
     'add_hotkey': 'ctrl+space',
     'download_hotkey': 'ctrl+shift+space',
-    'clipboard_only': 'false',
+    # Only read the current clipboard contents when adding a link.
+    # This avoids sending Ctrl+C and works when the user has copied
+    # the URL manually before pressing the hotkey.
+    'clipboard_only': 'true',
 }
 
 # Loaded configuration shared across functions


### PR DESCRIPTION
## Summary
- default to using clipboard contents when adding URLs
- update docs for the new behaviour

## Testing
- `flake8 scripts/main_windows_strict.py`
- `pip install -r requirements.txt` *(fails: No matching distribution found for pywin32)*

------
https://chatgpt.com/codex/tasks/task_e_688402e230148333bc589f7ad81505ac