### PR TITLE
Use sorted-list file for sorting helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ The first launch creates a `Downloads/` directory with these subfolders:
 - `Pictures/Wildberries/` – Wildberries product images
 
 All runtime files (config, logs and the download list) are stored in the `system/` folder next to the executable.
+
+## Sorting helper
+
+The `sorted.py` script scans directories listed in `sorted-list.txt` and copies
+original images into a `Sorted/` folder located next to the script. Each line
+in `sorted-list.txt` should contain an absolute path to a directory. Only files
+without size suffixes such as `-150x150` or `-scaled` are collected. Run the
+script with:
+
+```bash
+python sorted.py
+```
+
+Missing directories are reported but skipped.

--- a/download-list.txt
+++ b/download-list.txt
@@ -1,4 +1,0 @@
-C:\Users\vladi\OneDrive\Изображения\Работа\Фиалки ок\uploads\2022\09\rm-salomeya-5.jpg
-C:\Users\vladi\OneDrive\Изображения\Работа\Фиалки ок\uploads\2022\09\rm-salomeya-6.jpg
-C:\Users\vladi\OneDrive\Изображения\Работа\Фиалки ок\uploads\2022\09\rm-salomeya.jpg
-C:\Users\vladi\OneDrive\Изображения\Работа\Фиалки ок\uploads\2022\09\rm-solnyshko-iyulya-2.jpg

--- a/sorted-list.txt
+++ b/sorted-list.txt
@@ -1,0 +1,1 @@
+C:\Users\vladi\OneDrive\Изображения\Работа\Фиалки ок\uploads

--- a/sorted.py
+++ b/sorted.py
@@ -1,16 +1,27 @@
 from pathlib import Path
+import re
 import shutil
 
-def copy_files(list_path: Path) -> None:
-    """Copy files listed in ``list_path`` to ``~/Downloads/Sorted``.
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
 
-    Each line in ``list_path`` should contain an absolute path to a file. The
-    file names are preserved when copying. Missing files are skipped.
-    """
+
+def is_original(file_path: Path) -> bool:
+    """Return True if ``file_path`` looks like an original image."""
+    if file_path.suffix.lower() not in IMAGE_EXTENSIONS:
+        return False
+    stem = file_path.stem
+    if stem.endswith("-scaled"):
+        return False
+    if re.search(r"-\d+x\d+$", stem):
+        return False
+    return True
+
+
+def gather_images(list_path: Path, target_dir: Path) -> None:
+    """Copy original images from directories listed in ``list_path`` to ``target_dir``."""
     if not list_path.exists():
         raise FileNotFoundError(f"List file not found: {list_path}")
 
-    target_dir = Path.home() / "Downloads" / "Sorted"
     target_dir.mkdir(parents=True, exist_ok=True)
 
     with list_path.open(encoding="utf-8") as f:
@@ -18,17 +29,22 @@ def copy_files(list_path: Path) -> None:
             line = raw_line.strip()
             if not line:
                 continue
-            source_path = Path(line)
-            if source_path.exists():
-                dest = target_dir / source_path.name
-                shutil.copy2(source_path, dest)
-            else:
-                print(f"Missing: {source_path}")
+            base_dir = Path(line)
+            if not base_dir.exists():
+                print(f"Missing: {base_dir}")
+                continue
+            for file_path in base_dir.rglob("*"):
+                if file_path.is_file() and is_original(file_path):
+                    dest = target_dir / file_path.name
+                    shutil.copy2(file_path, dest)
+
 
 def main() -> None:
     script_dir = Path(__file__).resolve().parent
-    list_file = script_dir / "download-list.txt"
-    copy_files(list_file)
+    list_file = script_dir / "sorted-list.txt"
+    target_dir = script_dir / "Sorted"
+    gather_images(list_file, target_dir)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Scan directories listed in `sorted-list.txt` for image files
- Copy only original images into a local `Sorted/` folder
- Document new image collector usage in the README

## Testing
- `python -m py_compile sorted.py`
- `python sorted.py`


------
https://chatgpt.com/codex/tasks/task_e_688faa4f9ca483339ced9845a5dba036